### PR TITLE
Change when the cursor via css is changed

### DIFF
--- a/src/css/Leaflet.StyleEditor.css
+++ b/src/css/Leaflet.StyleEditor.css
@@ -115,6 +115,7 @@
     font-size: 15px;
     font-weight: 600;
     color: #FFFFFF;
+    cursor: pointer;
 }
 .styleeditor-inBtn {
     background-image: url('../img/icon.png');
@@ -156,6 +157,7 @@
     float: left;
     margin-right: 15px;
     border: 1px solid white;
+    cursor: pointer;
 }
 .leaflet-styleeditor-sizeicon:hover {
     border: 1px solid black;


### PR DESCRIPTION
in the old version the control showed the 'hand' pointer for nearly every element.

This commit sets the pointer cursor only for the colors.
