### PR TITLE
Fixed invalid syntax in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Leaflet.StyleEditor",
-  "version": "0.1.1",
+  "version": "0.1.2,
   "homepage": "https://github.com/dwilhelm89/Leaflet.StyleEditor",
   "authors": [
     "Dennis Wilhelm <dwilhelm89@googlemail.com>"
@@ -8,7 +8,7 @@
   "description": "Edit the style of features drawn within Leaflet.",
   "main": [
     "dist/javascript/Leaflet.StyleEditor.min.js",
-    "dist/css/Leaflet.StyleEditor.min.css",
+    "dist/css/Leaflet.StyleEditor.min.css"
   ],
   "moduleType": [
     "globals"


### PR DESCRIPTION
Syntax seems to be wrong (again?)

Hope this fixes my problem regarding this output:

```
bower install Leaflet.StyleEditor
bower Leaflet.StyleEditor#* not-cached git://github.com/dwilhelm89/Leaflet.StyleEditor.git#*
bower Leaflet.StyleEditor#*    resolve git://github.com/dwilhelm89/Leaflet.StyleEditor.git#*
bower Leaflet.StyleEditor#*   download https://github.com/dwilhelm89/Leaflet.StyleEditor/archive/v0.1.1.tar.gz
bower Leaflet.StyleEditor#*    extract archive.tar.gz
bower Leaflet.StyleEditor#* EMALFORMED Failed to read /tmp/niko/bower/Leaflet.StyleEditor-16631-JPgnaQ/bower.json

Additional error details:
Unexpected token ]
```
