### PR TITLE
Fixed misssing semicolon

### DIFF
--- a/src/javascript/Leaflet.StyleEditor.js
+++ b/src/javascript/Leaflet.StyleEditor.js
@@ -206,7 +206,7 @@ L.Control.StyleEditor = L.Control.extend({
         							layer.setIcon(icon);
         						}
         					});
-        				}
+        				};
         			}
         		}
 


### PR DESCRIPTION
JsHint complained about a missing semicolon in the code I submitted in my first PR.
I guess this should be fixed (maybe this is the reason why the styleEditor breaks my require.js optimize result)
