### PR TITLE
Set the marker's Popup in the right position.

### DIFF
--- a/src/javascript/Leaflet.StyleForms.js
+++ b/src/javascript/Leaflet.StyleForms.js
@@ -65,7 +65,9 @@ L.StyleForms = L.Class.extend({
 
             var newIcon = new L.Icon({
                 iconUrl: this.options.markerApi + 'pin-' + markerStyle.size + '-' + markerStyle.icon + '+' + markerStyle.color + '.png',
-                iconSize: iconSize
+                iconSize: iconSize,
+                iconAnchor: [iconSize[0] / 2, iconSize[1] / 2],
+                popupAnchor: [0, -iconSize[1] / 2]
             });
             var currentElement = this.options.currentElement.target;
             currentElement.setIcon(newIcon);


### PR DESCRIPTION
When a user change the style of the marker, the popup opens in a wrong position. To fix this problem, you have to set the right `popupAnchor` point from which the popup should open.