### PR TITLE
PopupContentElement - fire changed event

### DIFF
--- a/src/javascript/FormElements/PopupContentElement.js
+++ b/src/javascript/FormElements/PopupContentElement.js
@@ -10,39 +10,8 @@ L.StyleEditor.formElements.PopupContentElement = L.StyleEditor.formElements.Form
   createContent: function () {
     let uiElement = this.options.uiElement
 
-    let textArea = L.DomUtil.create('textarea', 'leaflet-styleeditor-input', uiElement)
-    this.options.descTextAreaField = textArea // keep the reference
-
-    L.DomEvent.addListener(textArea, 'change', function () {
-      let selectedElement = this.options.styleEditorOptions.util.getCurrentElement()
-      setMarkerText(textArea.value, selectedElement)
-    }, this)
-
-    function setMarkerText (inputText, currentElement) {
-      inputText = inputText + ''
-
-      // check whether a layer is part of a layerGroup
-      let layers = [currentElement]
-      if (currentElement instanceof L.LayerGroup) {
-        layers = Object.values(currentElement._layers)
-      }
-
-      // update layer (or all layers of a layerGroup)
-      for (let i = 0; i < layers.length; i++) {
-        let marker = layers[i]
-        if (marker && marker.getPopup && marker.bindPopup) {
-          let popup1 = marker.getPopup()
-          if (popup1) {
-            popup1.setContent(inputText)
-          } else {
-            marker.bindPopup(inputText)
-          }
-          // tmp store the text content for init next time
-          marker.options = marker.options || {}
-          marker.options.popupContent = inputText
-        }
-      }
-    }
+    let textArea = this.options.descTextAreaField = L.DomUtil.create('textarea', 'leaflet-styleeditor-input', uiElement)
+    L.DomEvent.addListener(textArea, 'change', this._setStyle, this)
   },
 
   /** set correct value */
@@ -52,6 +21,35 @@ L.StyleEditor.formElements.PopupContentElement = L.StyleEditor.formElements.Form
     if (selectedElement && selectedElement.options) {
       this.options.descTextAreaField.value = selectedElement.options.popupContent || ''
     }
-  }
+  },
 
+  /** communicate popupContent value */
+  _setStyle: function () {
+    let currentElement = this.options.styleEditorOptions.util.getCurrentElement()
+    let inputText = this.options.descTextAreaField.value
+
+    // check whether a layer is part of a layerGroup
+    let layers = [currentElement]
+    if (currentElement instanceof L.LayerGroup) {
+      layers = Object.values(currentElement._layers)
+    }
+
+    // update layer (or all layers of a layerGroup)
+    for (let i = 0; i < layers.length; i++) {
+      let marker = layers[i]
+      if (marker && marker.getPopup && marker.bindPopup) {
+        let popup1 = marker.getPopup()
+        if (popup1) {
+          popup1.setContent(inputText)
+        } else {
+          marker.bindPopup(inputText)
+        }
+        // tmp store the text content for init next time
+        marker.options = marker.options || {}
+        marker.options.popupContent = inputText
+      }
+    }
+
+    this.setStyle(inputText)
+  }
 })


### PR DESCRIPTION
There were not styleeditor:changed events for changes in PopupContentElement.

FormElements should pass changes of the element through FormElement.setStyle to higher levels. This call was missing and therefor no event was fired.