### PR TITLE
Fix local import of marker icon

### DIFF
--- a/src/css/Leaflet.StyleEditor.css
+++ b/src/css/Leaflet.StyleEditor.css
@@ -209,7 +209,7 @@ textarea.leaflet-styleeditor-input {
     border:1px solid black;
 }
 .leaflet-styleeditor-sizeicon {
-    background-image: url('../../node_modules/leaflet/dist/images/marker-icon-2x.png');
+    background-image: url('~leaflet/dist/images/marker-icon-2x.png');
     background-repeat: no-repeat;
     float: left;
     margin-right: 15px;


### PR DESCRIPTION
If you have Leaflet-StyleEditor as dependency which itself depends on
Leaflet, you already have leaflet in your root node_modules. This means
it will not be installed for Leaflet-Styleeditor. Hence, the import of
the marcer icon will not work.